### PR TITLE
Added addSecondaryStorage API command

### DIFF
--- a/lib/cloudstack_ruby_client/api/infra_api.rb
+++ b/lib/cloudstack_ruby_client/api/infra_api.rb
@@ -37,7 +37,8 @@ module CloudstackRubyClient
                     :update_host,
                     :delete_host,
                     :dedicate_host,
-                    :reconnect_host
+                    :reconnect_host,
+                    :add_secondary_storage
     end
   end
 end


### PR DESCRIPTION
The CloudstackApiClient class did not provide a method for the addSecondaryStorage command (http://cloudstack.apache.org/docs/api/apidocs-4.0.0/root_admin/addSecondaryStorage.html). This pull request adds that command and has been tested against ACS 4.0.0
