### PR TITLE
Added extra API call and test for "migrate_virtual_machine_with_volume"

### DIFF
--- a/lib/cloudstack_ruby_client/api/vm_api.rb
+++ b/lib/cloudstack_ruby_client/api/vm_api.rb
@@ -15,6 +15,7 @@ module CloudstackRubyClient
                     :change_service_for_virtual_machine,
                     :assign_virtual_machine,
                     :migrate_virtual_machine,
+                    :migrate_virtual_machine_with_volume,
                     :recover_virtual_machine,
                     :add_nic_to_virtual_machine,
                     :remove_nic_from_virtual_machine,

--- a/lib/cloudstack_ruby_client/version.rb
+++ b/lib/cloudstack_ruby_client/version.rb
@@ -1,3 +1,3 @@
 module CloudstackRubyClient
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/test/unit/vm_test.rb
+++ b/test/unit/vm_test.rb
@@ -103,6 +103,12 @@ class VirtualMachineTest < Test::Unit::TestCase
     end
   end
 
+  def test_migrate_virtual_machine_with_volume
+    assert_raise(ArgumentError) do
+      @client.migrate_virtual_machine_with_volume
+    end
+  end
+
   def test_recover_virtual_machine
     assert_raise(ArgumentError) do
       @client.recover_virtual_machine


### PR DESCRIPTION
Hi, we wanted to use the gem to test migration of a machine with local storage.  I have packaged it and I am currently using it from our local Nexus server, could you review the changes and merge if possible?

Thanks.