### PR TITLE
added call to find host suitable for migration

### DIFF
--- a/lib/cloudstack_ruby_client/api/infra_api.rb
+++ b/lib/cloudstack_ruby_client/api/infra_api.rb
@@ -42,7 +42,8 @@ module CloudstackRubyClient
                     :add_secondary_storage,
                     :prepare_host_for_maintenance,
                     :cancel_host_maintenance,
-                    :update_host_password
+                    :update_host_password,
+                    :find_hosts_for_migration
     end
   end
 end


### PR DESCRIPTION
For a router migration script I was missing this call to find a host that is suitable to migrate VMs to, including systemvms.
